### PR TITLE
Expose Dahua intrusion event payload to binary sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,20 @@ as they fire. That can help you understand the events. Or you can HA and open De
 "Listen to events" enter `dahua_event_received` and then click "Start Listening" and wait for events to fire (you might
 need to walk in front of your cam to make motion events fire, or press a button, etc)
 
+## Intrusion event coordinates
+
+Binary sensors created for Dahua intrusion (`CrossRegionDetection`) rules expose the most recent event payload so that the
+bounding box and center coordinates can be used in automations or scripts. The example below shows how to read these values
+after an intrusion event has triggered:
+
+```jinja2
+{{ state_attr('binary_sensor.cam13_cross_region_detection', 'bounding_box') }}
+{{ state_attr('binary_sensor.cam13_cross_region_detection', 'center') }}
+```
+
+Each time the event fires, the `event_payload` attribute is updated and then cleared when the event stops, ensuring that the
+coordinates reflect the last detection only while the alarm is active.
+
 ## Example Code Events
 | Code | Description |
 | ----- | ----------- |

--- a/custom_components/dahua/binary_sensor.py
+++ b/custom_components/dahua/binary_sensor.py
@@ -131,3 +131,29 @@ class DahuaEventSensor(DahuaBaseEntity, BinarySensorEntity):
     def should_poll(self) -> bool:
         """Return True if entity has to be polled for state.  False if entity pushes its state to HA"""
         return False
+
+    @property
+    def extra_state_attributes(self):
+        attributes = dict(super().extra_state_attributes)
+
+        event_payload = self._coordinator.get_last_event_payload(self._event_name)
+        if event_payload:
+            attributes["event_payload"] = event_payload
+
+            if self._event_name == "CrossRegionDetection":
+                bounding_box = event_payload.get("BoundingBox")
+                center = event_payload.get("Center")
+
+                obj = event_payload.get("Object")
+                if isinstance(obj, dict):
+                    if bounding_box is None:
+                        bounding_box = obj.get("BoundingBox")
+                    if center is None:
+                        center = obj.get("Center")
+
+                if bounding_box is not None:
+                    attributes["bounding_box"] = bounding_box
+                if center is not None:
+                    attributes["center"] = center
+
+        return attributes


### PR DESCRIPTION
## Summary
- store the most recent event payload on the coordinator and expose a helper to read it
- extend Dahua binary sensors to surface bounding box and center data for CrossRegionDetection events
- document how to access the intrusion coordinates from Home Assistant automations

## Testing
- pytest *(fails: missing Home Assistant test fixtures in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb1c229d708328af1252293232986d